### PR TITLE
Check fingerprint

### DIFF
--- a/aws-throwaway/src/lib.rs
+++ b/aws-throwaway/src/lib.rs
@@ -333,6 +333,7 @@ sudo systemctl start ssh
             public_ip,
             private_ip,
             self.host_public_key_bytes.clone(),
+            self.host_public_key.clone(),
             &self.client_private_key,
         )
         .await

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ This tracking is stored locally on your machine or in some kind of shared reposi
 This makes sense when you have important production data on the line.
 But when you are working with resources that contain nothing of value and will soon be destroyed, that approach is needlessly brittle and leaves it easy to have costly unaccounted for AWS resources.
 
-Rather than attempting to individually track each resource created like terraform does, aws-throwaway attaches a single user unique [AWS tag](https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html) to every resource it creates allowing it destroy all its resources without depending on local state.
+Rather than attempting to individually track each resource created like terraform does, aws-throwaway attaches a single user unique [AWS tag](https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html) to every resource it creates allowing it to destroy all its resources without depending on local state.
 
 Consider this snippet from the example earlier:
 


### PR DESCRIPTION
Previously when manually connecting to an instance, ssh would pop up a message like this:
```console
rukai@memes foo$ TERM=xterm ssh -i key ubuntu@18.204.219.189
The authenticity of host '18.204.219.189 (18.204.219.189)' can't be established.
ED25519 key fingerprint is SHA256:qGAC8ry5iMndcPb3lxy/o6PmoEA3gjCDk/zofJMP/lE.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])?
```

There was no way to actually check the fingerprint, so instead we would just accept it, leaving us open to MitM attacks.
This PR does the following:
* exposes public methods to retrieve the host public key in useful formats in case the user wants to connect with their own ssh client.
* alters the bash script emitted by `ssh_instructions` to perform checking of the fingerprint
   + unfortunately openssh is silly and the only way to do this is to create a temporary known_hosts file but it works