### PR TITLE
release 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-throwaway"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/shotover/aws-throwaway"


### PR DESCRIPTION
Doing a release to get this into shotover: https://github.com/shotover/aws-throwaway/pull/2

No breaking changes so 0.1.1 is fine.