### PR TITLE
fix GA release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   publish-crates-io:
     name: "Publish to crates.io"
-    needs: prepublish-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The CI was misconfigured due to a copypaste mistake, causing the release to fail: https://github.com/shotover/aws-throwaway/actions/runs/5722371700
I've manually performed the release locally but this should fix it for next time.