### PR TITLE
allow user to set application specific tags

### DIFF
--- a/aws-throwaway/examples/aws-throwaway-test.rs
+++ b/aws-throwaway/examples/aws-throwaway-test.rs
@@ -1,4 +1,4 @@
-use aws_throwaway::{Aws, InstanceType};
+use aws_throwaway::{Aws, CleanupResources, InstanceType};
 use std::path::Path;
 use tracing_subscriber::EnvFilter;
 
@@ -10,7 +10,7 @@ async fn main() {
         .with_writer(non_blocking)
         .init();
 
-    let aws = Aws::new().await;
+    let aws = Aws::new(CleanupResources::AllResources).await;
     let instance = aws.create_ec2_instance(InstanceType::T2Micro, 8).await;
 
     instance

--- a/aws-throwaway/examples/create-instance.rs
+++ b/aws-throwaway/examples/create-instance.rs
@@ -1,7 +1,9 @@
-use aws_throwaway::{Aws, InstanceType};
+use aws_throwaway::{Aws, CleanupResources, InstanceType};
 use clap::Parser;
 use std::str::FromStr;
 use tracing_subscriber::EnvFilter;
+
+const AWS_THROWAWAY_TAG: &str = "create-instance";
 
 #[tokio::main]
 async fn main() {
@@ -13,12 +15,13 @@ async fn main() {
 
     let args = Args::parse();
     if args.cleanup {
-        Aws::cleanup_resources_static().await;
+        Aws::cleanup_resources_static(CleanupResources::WithAppTag(AWS_THROWAWAY_TAG.to_owned()))
+            .await;
         println!("All AWS throwaway resources have been deleted")
     } else if let Some(instance_type) = args.instance_type {
         println!("Creating instance of type {instance_type}");
 
-        let aws = Aws::new().await;
+        let aws = Aws::new(CleanupResources::WithAppTag(AWS_THROWAWAY_TAG.to_owned())).await;
         let instance_type = InstanceType::from_str(&instance_type).unwrap();
         let instance = aws.create_ec2_instance(instance_type, 20).await;
 

--- a/aws-throwaway/src/tags.rs
+++ b/aws-throwaway/src/tags.rs
@@ -1,0 +1,100 @@
+use aws_sdk_ec2::operation::describe_tags::DescribeTagsOutput;
+use aws_sdk_ec2::types::Filter;
+use aws_sdk_ec2::types::{ResourceType, Tag, TagSpecification};
+
+/// Specify the cleanup process to use.
+pub enum CleanupResources {
+    /// Cleanup resources created by all [`Aws`] instances that use [`CleanupResources::WithAppTag`] of the same tag.
+    /// It is highly reccomended that this tag is hardcoded, generating this tag could easily lead to forgotten resources.
+    WithAppTag(String),
+    /// Cleanup resources created by all [`Aws`] instances regardless of whether it was created via [`CleanupResources::AllResources`] or [`CleanupResources::ResourcesMatchingTag`]
+    AllResources,
+}
+
+// include a magic number in the keyname to avoid collisions
+// This can never change or we may fail to cleanup resources.
+const USER_TAG_NAME: &str = "aws-throwaway-23c2d22c-d929-43fc-b2a4-c1c72f0b733f:user";
+const APP_TAG_NAME: &str = "aws-throwaway-23c2d22c-d929-43fc-b2a4-c1c72f0b733f:app";
+
+pub(crate) struct Tags {
+    pub user_name: String,
+    pub cleanup: CleanupResources,
+}
+
+impl Tags {
+    pub fn create_tags(
+        &self,
+        resource_type: ResourceType,
+        resource_name: &'static str,
+    ) -> TagSpecification {
+        let mut builder = TagSpecification::builder()
+            .resource_type(resource_type)
+            .tags(Tag::builder().key("Name").value(resource_name).build())
+            .tags(
+                Tag::builder()
+                    .key(USER_TAG_NAME)
+                    .value(&self.user_name)
+                    .build(),
+            );
+
+        builder = match &self.cleanup {
+            CleanupResources::WithAppTag(tag) => {
+                builder.tags(Tag::builder().key(APP_TAG_NAME).value(tag).build())
+            }
+            CleanupResources::AllResources => builder,
+        };
+
+        builder.build()
+    }
+
+    pub async fn fetch_user_tags(
+        &self,
+        client: &aws_sdk_ec2::Client,
+        resource_type: &str,
+    ) -> DescribeTagsOutput {
+        client
+            .describe_tags()
+            .set_filters(Some(vec![
+                Filter::builder()
+                    .name(format!("tag:{USER_TAG_NAME}"))
+                    .values(&self.user_name)
+                    .build(),
+                Filter::builder()
+                    .name("resource-type")
+                    .values(resource_type)
+                    .build(),
+            ]))
+            .send()
+            .await
+            .map_err(|e| e.into_service_error())
+            .unwrap()
+    }
+
+    pub async fn fetch_app_tags(
+        &self,
+        client: &aws_sdk_ec2::Client,
+        resource_type: &str,
+    ) -> Option<DescribeTagsOutput> {
+        match &self.cleanup {
+            CleanupResources::WithAppTag(tag) => Some(
+                client
+                    .describe_tags()
+                    .set_filters(Some(vec![
+                        Filter::builder()
+                            .name(format!("tag:{APP_TAG_NAME}"))
+                            .values(tag)
+                            .build(),
+                        Filter::builder()
+                            .name("resource-type")
+                            .values(resource_type)
+                            .build(),
+                    ]))
+                    .send()
+                    .await
+                    .map_err(|e| e.into_service_error())
+                    .unwrap(),
+            ),
+            CleanupResources::AllResources => None,
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ It was developed for the use case of benchmarking.
 aws-throwaway makes it trivial to spin up an instance, interact with it, and then destroy it.
 
 ```rust
-let aws = Aws::new().await;
+let aws = Aws::new(CleanupResources::AllResources).await;
 
 let instance = aws.create_ec2_instance(InstanceType::T2Micro).await;
 let output = instance.ssh().shell("echo 'Hello world!'").await;
@@ -57,7 +57,7 @@ Rather than attempting to individually track each resource created like terrafor
 Consider this snippet from the example earlier:
 
 ```rust
-let aws = Aws::new().await;
+let aws = Aws::new(CleanupResources::AllResources).await;
 let instance = aws.create_ec2_instance().await;
 ```
 
@@ -80,7 +80,7 @@ Even resources created by aws-throwaway by the same user in a different applicat
 
 It is recommended to cleanup your resources at 3 points:
 
-1. When you start your application. This is actually done automatically for you by `Aws::new()`.
+1. When you start your application. This is actually done automatically for you by `Aws::new(..)`.
 2. When your application finishes. You should manually call `aws.cleanup_resources()`
 3. You should provide a cli flag (or similar) in your application that specifically triggers cleanup and nothing else. e.g. `application --cleanup-aws-resources` You can call `Aws::cleanup_resources_static()` to achieve this.
 


### PR DESCRIPTION
In order to support running windsock within ec2-cargo we will need to tweak our design a bit to allow an ec2 instance to spin up more ec2 instances.
This is currently impossible because calling the `Aws::new()` constructor within an ec2 instance created by aws-throwaway will immediately destroy the instance we are running in!

This PR introduces a new enum:
```rust
pub enum CleanupResources {
    WithAppTag(String),
    AllResources,
}
```
This enum is passed into the `Aws::new(..)` constructor giving the user some control over the cleanup process used: 

* If `CleanupResources::AllResources` is used the existing functionality is maintained - all resources created by any usage of aws-throwaway are destroyed during cleanup.
* If `CleanupResources::WithAppTag` is used all resources created are tagged as belonging to the specified app and can only be terminated by aws-throwaway instances claiming to be that app or a `CleanupResource::AllResources`

We would then solve our windsock in ec2-cargo issue by:
* ec2-cargo is configured as `CleanupResources::AllResources`
* windsock is configured as `CleanupResources::WithAppTag("windsock".to_owned())`

This way ec2-cargo will cleanup all resources on close ensuring nothing is left over.
Windsock can cleanup its own resources without destroying the ec2-cargo instance which is hosting it.

As a bonus this also allows the usage of running multiple separately tagged apps concurrently. Say windsock and a testing instance.

## Alternative design I considered

Use an arg or env var to tell the child aws-throwaway app to not cleanup.
This nearly solves our problem but it would mean that running windsock multiple times in the one ec2-cargo session would start to collect many idle instances before the ec2-cargo session is shutdown to clear them out. This could be quite expensive!

## Alternative design I did not consider

We absolutely do not want this library to grow local state to track resources as that would betray its entire point.
If we found that we needed that level of fine-grained control we should just go use terraform or something instead.