### PR TITLE
Release aws-throwaway v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-throwaway"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/shotover/aws-throwaway"


### PR DESCRIPTION
Breaking change due to e.g. https://github.com/shotover/aws-throwaway/pull/7 https://github.com/shotover/aws-throwaway/pull/6