### PR TITLE
Various API cleanup

### DIFF
--- a/aws-throwaway/examples/aws-throwaway-test.rs
+++ b/aws-throwaway/examples/aws-throwaway-test.rs
@@ -1,4 +1,4 @@
-use aws_throwaway::{Aws, CleanupResources, InstanceType};
+use aws_throwaway::{Aws, CleanupResources, Ec2InstanceDefinition, InstanceType};
 use std::path::Path;
 use tracing_subscriber::EnvFilter;
 
@@ -11,7 +11,9 @@ async fn main() {
         .init();
 
     let aws = Aws::new(CleanupResources::AllResources).await;
-    let instance = aws.create_ec2_instance(InstanceType::T2Micro, 8).await;
+    let instance = aws
+        .create_ec2_instance(Ec2InstanceDefinition::new(InstanceType::T2Micro))
+        .await;
 
     instance
         .ssh()

--- a/aws-throwaway/examples/create-instance.rs
+++ b/aws-throwaway/examples/create-instance.rs
@@ -1,4 +1,4 @@
-use aws_throwaway::{Aws, CleanupResources, InstanceType};
+use aws_throwaway::{Aws, CleanupResources, Ec2InstanceDefinition, InstanceType};
 use clap::Parser;
 use std::str::FromStr;
 use tracing_subscriber::EnvFilter;
@@ -23,7 +23,11 @@ async fn main() {
 
         let aws = Aws::new(CleanupResources::WithAppTag(AWS_THROWAWAY_TAG.to_owned())).await;
         let instance_type = InstanceType::from_str(&instance_type).unwrap();
-        let instance = aws.create_ec2_instance(instance_type, 20).await;
+        let instance = aws
+            .create_ec2_instance(
+                Ec2InstanceDefinition::new(instance_type).volume_size_gigabytes(20),
+            )
+            .await;
 
         let result = instance.ssh().shell("lsb_release -a").await;
         println!("Created instance running:\n{}", result.stdout);

--- a/aws-throwaway/src/cpu_arch.rs
+++ b/aws-throwaway/src/cpu_arch.rs
@@ -1,0 +1,42 @@
+use aws_sdk_ec2::types::InstanceType;
+
+pub enum CpuArch {
+    X86_64,
+    Aarch64,
+}
+
+impl CpuArch {
+    pub fn get_ubuntu_arch_identifier(&self) -> &'static str {
+        match self {
+            CpuArch::X86_64 => "amd64",
+            CpuArch::Aarch64 => "arm64",
+        }
+    }
+}
+
+pub fn get_arch_of_instance_type(instance_type: InstanceType) -> CpuArch {
+    // Instance names look something like:
+    // type + revision_number + subtypes + '.' + size
+    // So say for example `Im4gn.large` would be split into:
+    // type = "Im"
+    // revision_number = 4
+    // subtypes = "gn"
+    // size = "large"
+    //
+    // The 'g' character existing in subtypes indicates that the instance type is a gravitron aka arm instance.
+    // We can check for the existence of 'g' to determine if we are aarch64 or x86_64
+    // This is a bit hacky because this format is not explicitly documented anywhere but the instance type naming does consistently follow this pattern.
+    let mut reached_revision_number = false;
+    for c in instance_type.as_str().chars() {
+        if !reached_revision_number {
+            if c.is_ascii_digit() {
+                reached_revision_number = true;
+            }
+        } else if c == '.' {
+            return CpuArch::X86_64;
+        } else if c == 'g' {
+            return CpuArch::Aarch64;
+        }
+    }
+    unreachable!("Cannot parse instance type: {instance_type:?}")
+}

--- a/aws-throwaway/src/ec2_instance.rs
+++ b/aws-throwaway/src/ec2_instance.rs
@@ -4,6 +4,7 @@ use tokio::{net::TcpStream, time::Instant};
 
 use crate::ssh::SshConnection;
 
+/// Represents a currently running EC2 instance and provides various methods for interacting with the instance.
 pub struct Ec2Instance {
     public_ip: IpAddr,
     private_ip: IpAddr,

--- a/aws-throwaway/src/ec2_instance_definition.rs
+++ b/aws-throwaway/src/ec2_instance_definition.rs
@@ -1,0 +1,24 @@
+use aws_sdk_ec2::types::InstanceType;
+
+/// Defines an instance that can be launched via [`Aws::create_ec2_instance`]
+pub struct Ec2InstanceDefinition {
+    pub(crate) instance_type: InstanceType,
+    pub(crate) volume_size_gb: u32,
+}
+
+impl Ec2InstanceDefinition {
+    /// Start defining an instance with the specified instance type
+    pub fn new(instance_type: InstanceType) -> Self {
+        Ec2InstanceDefinition {
+            instance_type,
+            volume_size_gb: 8,
+        }
+    }
+
+    // Set instance to have a root volume of the specified size.
+    // Defaults to 8GB.
+    pub fn volume_size_gigabytes(mut self, size_gb: u32) -> Self {
+        self.volume_size_gb = size_gb;
+        self
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ aws-throwaway makes it trivial to spin up an instance, interact with it, and the
 ```rust
 let aws = Aws::new(CleanupResources::AllResources).await;
 
-let instance = aws.create_ec2_instance(InstanceType::T2Micro).await;
+let instance = aws.create_ec2_instance(Ec2InstanceDefinition::new(InstanceType::T2Micro)).await;
 let output = instance.ssh().shell("echo 'Hello world!'").await;
 println!("output from ec2 instance: {}", output.stdout);
 
@@ -58,7 +58,7 @@ Consider this snippet from the example earlier:
 
 ```rust
 let aws = Aws::new(CleanupResources::AllResources).await;
-let instance = aws.create_ec2_instance().await;
+let instance = aws.create_ec2_instance(Ec2InstanceDefinition::new(InstanceType::T2Micro)).await;
 ```
 
 Behind the scenes this creates various kinds of AWS resources. e.g. keypairs, security groups, ec2 instances


### PR DESCRIPTION
Various cleanups:

* added doc comments to all publically exposed types
* pulled `CpuArch` into its own file
* `create_ec2_instance` now takes a builder type `Ec2InstanceDefinition`, we will need this in the future as we make instance creation more configurable.
* `ec2_instance` module is no longer public, instead `Ec2Instance` is just reexported from the main module.