### PR TITLE
shell_stdout_lines returns an error

### DIFF
--- a/aws-throwaway/examples/aws-throwaway-test.rs
+++ b/aws-throwaway/examples/aws-throwaway-test.rs
@@ -35,6 +35,7 @@ async fn main() {
     let mut receiver = instance.ssh().shell_stdout_lines("cat readme.md").await;
     println!();
     while let Some(line) = receiver.recv().await {
+        let line = line.unwrap();
         println!("Received: {line}");
     }
 


### PR DESCRIPTION
Previously we were just using this method to run user facing commands, so it was up to the user to determine if the command failed or not.
Or in another case, it was running commands that would identify a failure via serialized messages sent to stdout.
So there was previously no need to return an Err.

However I would like to start using this method for tests where we run a command that demonstrates failure via non-zero exit code.
So we need this error to know if we should fail the test or not.

I also whacked on some documentation to some of the methods here.