### PR TITLE
Support ubuntu 20.04

### DIFF
--- a/aws-throwaway/examples/create-instance.rs
+++ b/aws-throwaway/examples/create-instance.rs
@@ -25,7 +25,9 @@ async fn main() {
         let instance_type = InstanceType::from_str(&instance_type).unwrap();
         let instance = aws
             .create_ec2_instance(
-                Ec2InstanceDefinition::new(instance_type).volume_size_gigabytes(20),
+                Ec2InstanceDefinition::new(instance_type)
+                    .volume_size_gigabytes(20)
+                    .os(args.instance_os.to_aws()),
             )
             .await;
 
@@ -49,5 +51,23 @@ pub struct Args {
     pub instance_type: Option<String>,
 
     #[clap(long)]
+    pub instance_os: InstanceOs,
+
+    #[clap(long)]
     pub cleanup: bool,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy)]
+pub enum InstanceOs {
+    Ubuntu20_04,
+    Ubuntu22_04,
+}
+
+impl InstanceOs {
+    fn to_aws(self) -> aws_throwaway::InstanceOs {
+        match self {
+            InstanceOs::Ubuntu20_04 => aws_throwaway::InstanceOs::Ubuntu20_04,
+            InstanceOs::Ubuntu22_04 => aws_throwaway::InstanceOs::Ubuntu22_04,
+        }
+    }
 }

--- a/aws-throwaway/src/ec2_instance_definition.rs
+++ b/aws-throwaway/src/ec2_instance_definition.rs
@@ -4,6 +4,7 @@ use aws_sdk_ec2::types::InstanceType;
 pub struct Ec2InstanceDefinition {
     pub(crate) instance_type: InstanceType,
     pub(crate) volume_size_gb: u32,
+    pub(crate) os: InstanceOs,
 }
 
 impl Ec2InstanceDefinition {
@@ -12,6 +13,7 @@ impl Ec2InstanceDefinition {
         Ec2InstanceDefinition {
             instance_type,
             volume_size_gb: 8,
+            os: InstanceOs::Ubuntu20_04,
         }
     }
 
@@ -21,4 +23,20 @@ impl Ec2InstanceDefinition {
         self.volume_size_gb = size_gb;
         self
     }
+
+    // Set the OS used by the instance.
+    // Defaults to `Ubuntu 22.04`
+    pub fn os(mut self, os: InstanceOs) -> Self {
+        self.os = os;
+        self
+    }
+}
+
+/// aws-throwaway needs to manually support each OS, so the only OS's you can use are those listed in this enum.
+/// Support for more (similar) OS's is welcome via pull request.
+#[derive(Clone, Copy)]
+#[non_exhaustive]
+pub enum InstanceOs {
+    Ubuntu20_04,
+    Ubuntu22_04,
 }


### PR DESCRIPTION
Adds an `os` method to the instance definition builder, this allows us to add support for any OS but for now we just support ubuntu 22.04 and ubuntu 20.04.

InstanceOs is set to non_exhaustive so we can add support for new OS's without it being a breaking change.