### PR TITLE
User specified VPC + subnet + securitygroup + ami

### DIFF
--- a/aws-throwaway/src/ec2_instance_definition.rs
+++ b/aws-throwaway/src/ec2_instance_definition.rs
@@ -6,6 +6,7 @@ pub struct Ec2InstanceDefinition {
     pub(crate) volume_size_gb: u32,
     pub(crate) network_interface_count: u32,
     pub(crate) os: InstanceOs,
+    pub(crate) ami: Option<String>,
 }
 
 impl Ec2InstanceDefinition {
@@ -16,6 +17,7 @@ impl Ec2InstanceDefinition {
             volume_size_gb: 8,
             network_interface_count: 1,
             os: InstanceOs::Ubuntu22_04,
+            ami: None,
         }
     }
 
@@ -41,6 +43,17 @@ impl Ec2InstanceDefinition {
     // Defaults to `Ubuntu 22.04`
     pub fn os(mut self, os: InstanceOs) -> Self {
         self.os = os;
+        self
+    }
+
+    /// Override the AMI used.
+    /// When used together with the `os` setting, the os setting is used to determine how to configure the instance while the specified AMI is used as the instances image.
+    /// Defaults to None which indicates that the appropriate AMI should be looked up via SSM.
+    ///
+    /// This option is useful when you have custom variation of the configured OS or if your user does not have access to SSM.
+    /// AMI's are region specific so be careful in picking your AMI.
+    pub fn override_ami(mut self, ami: Option<String>) -> Self {
+        self.ami = ami;
         self
     }
 }


### PR DESCRIPTION
closes https://github.com/shotover/aws-throwaway/issues/23

Allows aws-throwaway to function in the following cases:
* The user does not have a default vpc+subnet configured
* The user wants to use aws-throwaway with a vpc+subnet different from the defaults.
* The custom security group is useful if the user does not have access to create a security group and needs to use a preexisting one.
* The custom AMI is useful if they have a custom build of a supported OS (or an OS that is similar enough to a supported OS) or if their user cannot access SSM to look up an appropriate AMI automatically.

All of these use cases are things I hit while trying to run aws-throwaway with internal aws account.