### PR TITLE
support connecting via VPNs/bastion instances

### DIFF
--- a/aws-throwaway/examples/aws-throwaway-test-multiple-instances.rs
+++ b/aws-throwaway/examples/aws-throwaway-test-multiple-instances.rs
@@ -10,7 +10,7 @@ async fn main() {
         .init();
 
     println!("Creating instances");
-    let aws = Aws::new(CleanupResources::AllResources).await;
+    let aws = Aws::builder(CleanupResources::AllResources).build().await;
     let (instance1, instance2) = tokio::join!(
         aws.create_ec2_instance(Ec2InstanceDefinition::new(InstanceType::T2Small)),
         aws.create_ec2_instance(

--- a/aws-throwaway/examples/create-instance.rs
+++ b/aws-throwaway/examples/create-instance.rs
@@ -21,7 +21,9 @@ async fn main() {
     } else if let Some(instance_type) = args.instance_type {
         println!("Creating instance of type {instance_type}");
 
-        let aws = Aws::new(CleanupResources::WithAppTag(AWS_THROWAWAY_TAG.to_owned())).await;
+        let aws = Aws::builder(CleanupResources::WithAppTag(AWS_THROWAWAY_TAG.to_owned()))
+            .build()
+            .await;
         let instance_type = InstanceType::from_str(&instance_type).unwrap();
         let network_interface_count = args.network_interfaces;
         let instance = aws

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ It was developed for the use case of benchmarking.
 aws-throwaway makes it trivial to spin up an instance, interact with it, and then destroy it.
 
 ```rust
-let aws = Aws::new(CleanupResources::AllResources).await;
+let aws = Aws::builder(CleanupResources::AllResources).build().await;
 
 let instance = aws.create_ec2_instance(Ec2InstanceDefinition::new(InstanceType::T2Micro)).await;
 let output = instance.ssh().shell("echo 'Hello world!'").await;
@@ -57,7 +57,7 @@ Rather than attempting to individually track each resource created like terrafor
 Consider this snippet from the example earlier:
 
 ```rust
-let aws = Aws::new(CleanupResources::AllResources).await;
+let aws = Aws::builder(CleanupResources::AllResources).build().await;
 let instance = aws.create_ec2_instance(Ec2InstanceDefinition::new(InstanceType::T2Micro)).await;
 ```
 


### PR DESCRIPTION
Progress towards https://github.com/shotover/aws-throwaway/issues/23

Currently aws-throwaway will connect to instances over the internet via the instances public ip address.
This is very convenient as it means the user does not have to setup any kind of VPN or bastion instance.
However being able to connect to a private ip via a VPN or bastion instance is very useful and even required in many environments.
To support both of these use cases, this PR introduces a config setting that decides whether to connect to instances private or public ip address.

This PR:
* refactors the `Aws` struct to be created by a builder struct: `AwsBuilder`
  + This builder will also be used to expose the functionality in https://github.com/shotover/aws-throwaway/pull/22
* adds a `use_public_addresses` method to the `AwsBuilder` struct
    + refer to the documentation of the method for more info.


I also changed aws-throwaway/examples/aws-throwaway-test.rs so that it doesnt leave files around making it more suitable for testing the project.
