### PR TITLE
Fix instance creation when use_public_addresses(false) + multi-eni

### DIFF
--- a/aws-throwaway/src/lib.rs
+++ b/aws-throwaway/src/lib.rs
@@ -521,10 +521,10 @@ impl Aws {
                     .availability_zone(AZ)
                     .build(),
             ))
-            .set_subnet_id(if elastic_ip.is_some() {
-                None
-            } else {
+            .set_subnet_id(if definition.network_interface_count == 1 {
                 Some(self.subnet_id.to_owned())
+            } else {
+                None
             })
             .min_count(1)
             .max_count(1)


### PR DESCRIPTION
Currently creating an instance with the following config will fail:
* use_public_addresses(false)
* network_interface_count(>1)

This PR fixes this by ensuring we do not specify an instance level subnet ID when `definition.network_interface_count > 1` this includes the previous case of `elastic_ip.is_some()` as that can only occur when `definition.network_interface_count > 1` 