### PR TITLE
Use sftp to transfer files instead of dd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -84,9 +97,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -558,6 +571,7 @@ dependencies = [
  "rand 0.10.0",
  "reqwest",
  "russh",
+ "russh-sftp",
  "serde",
  "serde_json",
  "ssh-key",
@@ -626,6 +640,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake2"
@@ -778,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -788,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -800,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -812,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -846,6 +863,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "core-foundation"
@@ -925,6 +962,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1189,6 +1232,18 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flurry"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
+dependencies = [
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
 ]
 
 [[package]]
@@ -1485,6 +1540,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2047,6 +2108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,10 +2261,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "num_cpus"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2275,6 +2355,29 @@ dependencies = [
  "tokio",
  "windows",
  "windows-strings",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2620,6 +2723,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +2913,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "russh-sftp"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "flurry",
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "russh-util"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,12 +3085,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
@@ -3020,6 +3155,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "seize"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "semver"
@@ -3379,6 +3520,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0.111"
 futures = "0.3.30"
 reqwest = "0.13.0"
 rand = "0.10.0"
+russh-sftp = "2.1.1"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.1", features = ["env-filter", "json"] }

--- a/aws-throwaway/src/ssh.rs
+++ b/aws-throwaway/src/ssh.rs
@@ -4,12 +4,9 @@ use russh::{
     ChannelMsg, Sig,
     client::{Config, Handle, Handler},
 };
+use russh_sftp::{client::SftpSession, protocol::OpenFlags};
 use std::{fmt::Display, io::Write, net::IpAddr, path::Path, sync::Arc, time::Duration};
-use tokio::{
-    fs::File,
-    io::{AsyncReadExt, BufReader},
-    net::TcpStream,
-};
+use tokio::{fs::File, io::AsyncReadExt, net::TcpStream};
 
 pub struct SshConnection {
     address: IpAddr,
@@ -206,11 +203,35 @@ impl SshConnection {
         let task = format!("pushing file from {source:?} to {}:{dest:?}", self.address);
         tracing::info!("{task}");
 
-        let source = File::open(source)
+        let channel = self.session.channel_open_session().await.unwrap();
+        channel.request_subsystem(true, "sftp").await.unwrap();
+        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
+        let mut file = sftp
+            .open_with_flags(
+                dest.to_str().unwrap(),
+                OpenFlags::WRITE | OpenFlags::TRUNCATE | OpenFlags::CREATE,
+            )
+            .await
+            .unwrap();
+
+        let mut source = File::open(source)
             .await
             .map_err(|e| anyhow!(e).context(format!("Failed to read from {source:?}")))
             .unwrap();
-        self.push_file_impl(&task, source, dest).await;
+
+        let mut bytes = vec![0u8; 1024 * 1024];
+        loop {
+            let read_count = source
+                .read(&mut bytes[..])
+                .await
+                .unwrap_or_else(|e| panic!("{task} failed to read from local disk with {e:?}"));
+            if read_count == 0 {
+                break;
+            }
+            tokio::io::AsyncWriteExt::write_all(&mut file, &bytes[0..read_count])
+                .await
+                .unwrap_or_else(|e| panic!("{task} failed to write to remote server with {e:?}"));
+        }
     }
 
     /// Create a file on the remote machine at `dest` with the provided bytes.
@@ -218,57 +239,19 @@ impl SshConnection {
         let task = format!("pushing raw bytes to {}:{dest:?}", self.address);
         tracing::info!("{task}");
 
-        let source = BufReader::new(bytes);
-        self.push_file_impl(&task, source, dest).await;
-    }
-
-    async fn push_file_impl<R: AsyncReadExt + Unpin>(&self, task: &str, source: R, dest: &Path) {
-        let mut channel = self.session.channel_open_session().await.unwrap();
-        let command = format!("cat > '{0}'\nchmod 777 {0}", dest.to_str().unwrap());
-        channel.exec(true, command).await.unwrap();
-
-        let mut stdout = vec![];
-        let mut stderr = vec![];
-        let mut status = None;
-        let mut failed = None;
-        channel.data(source).await.unwrap();
-        channel.eof().await.unwrap();
-        while let Some(msg) = channel.wait().await {
-            match msg {
-                ChannelMsg::Data { data } => stdout.write_all(&data).unwrap(),
-                ChannelMsg::ExtendedData { data, ext } => {
-                    if ext == 1 {
-                        stderr.write_all(&data).unwrap()
-                    } else {
-                        tracing::warn!(
-                            "received unknown extended data with extension type {ext} containing: {:?}",
-                            data.to_vec()
-                        )
-                    }
-                }
-                ChannelMsg::ExitStatus { exit_status } => {
-                    status = Some(exit_status);
-                    // cant exit immediately, there might be more data still
-                }
-                ChannelMsg::ExitSignal {
-                    signal_name,
-                    core_dumped,
-                    error_message,
-                    ..
-                } => {
-                    failed = Some(format!(
-                        "killed via signal {signal_name:?} core_dumped={core_dumped} {error_message:?}"
-                    ))
-                }
-                _ => {}
-            }
-        }
-        let output = CommandOutput {
-            stdout: String::from_utf8(stdout).unwrap(),
-            stderr: String::from_utf8(stderr).unwrap(),
-        };
-
-        check_results(task, failed, status, &output);
+        let channel = self.session.channel_open_session().await.unwrap();
+        channel.request_subsystem(true, "sftp").await.unwrap();
+        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
+        let mut file = sftp
+            .open_with_flags(
+                dest.to_str().unwrap(),
+                OpenFlags::WRITE | OpenFlags::TRUNCATE | OpenFlags::CREATE,
+            )
+            .await
+            .unwrap();
+        tokio::io::AsyncWriteExt::write_all(&mut file, bytes)
+            .await
+            .unwrap_or_else(|e| panic!("{task} failed to write to remote server with {e:?}"));
     }
 
     /// Pull a file from the remote machine to the local machine
@@ -276,50 +259,29 @@ impl SshConnection {
         let task = format!("pulling file from {}:{source:?} to {dest:?}", self.address);
         tracing::info!("{task}");
 
-        let mut channel = self.session.channel_open_session().await.unwrap();
-        let command = format!("cat '{}'", source.to_str().unwrap());
-        channel.exec(true, command).await.unwrap();
+        let channel = self.session.channel_open_session().await.unwrap();
+        channel.request_subsystem(true, "sftp").await.unwrap();
+        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
+        let mut file = sftp.open(source.to_str().unwrap()).await.unwrap();
 
-        let mut out = File::create(dest).await.unwrap();
-        let mut stderr = vec![];
-        let mut status = None;
-        let mut failed = None;
-        channel.eof().await.unwrap();
-        while let Some(msg) = channel.wait().await {
-            match msg {
-                ChannelMsg::Data { data } => tokio::io::AsyncWriteExt::write_all(&mut out, &data)
-                    .await
-                    .unwrap(),
-                ChannelMsg::ExtendedData { data, ext } => {
-                    if ext == 1 {
-                        stderr.write_all(&data).unwrap()
-                    } else {
-                        tracing::warn!(
-                            "received unknown extended data with extension type {ext} containing: {:?}",
-                            data.to_vec()
-                        )
-                    }
-                }
-                ChannelMsg::ExitStatus { exit_status } => {
-                    status = Some(exit_status);
-                    // cant exit immediately, there might be more data still
-                }
-                ChannelMsg::ExitSignal {
-                    signal_name,
-                    core_dumped,
-                    error_message,
-                    ..
-                } => {
-                    failed = Some(format!(
-                        "killed via signal {signal_name:?} core_dumped={core_dumped} {error_message:?}"
-                    ))
-                }
-                _ => {}
+        let mut dest = File::create(dest)
+            .await
+            .map_err(|e| anyhow!(e).context(format!("Failed to read from {source:?}")))
+            .unwrap();
+
+        let mut bytes = vec![0u8; 1024 * 1024];
+        loop {
+            let read_count = file
+                .read(&mut bytes[..])
+                .await
+                .unwrap_or_else(|e| panic!("{task} failed to read from local disk with {e:?}"));
+            if read_count == 0 {
+                break;
             }
+            tokio::io::AsyncWriteExt::write_all(&mut dest, &bytes[0..read_count])
+                .await
+                .unwrap_or_else(|e| panic!("{task} failed to write to remote server with {e:?}"));
         }
-
-        let output = String::from_utf8(stderr).unwrap();
-        check_results(&task, failed, status, &output);
     }
 }
 

--- a/aws-throwaway/src/ssh.rs
+++ b/aws-throwaway/src/ssh.rs
@@ -4,9 +4,16 @@ use russh::{
     ChannelMsg, Sig,
     client::{Config, Handle, Handler},
 };
-use russh_sftp::{client::SftpSession, protocol::OpenFlags};
+use russh_sftp::{
+    client::SftpSession,
+    protocol::{FileAttributes, OpenFlags},
+};
 use std::{fmt::Display, io::Write, net::IpAddr, path::Path, sync::Arc, time::Duration};
-use tokio::{fs::File, io::AsyncReadExt, net::TcpStream};
+use tokio::{
+    fs::File,
+    io::{AsyncRead, BufReader},
+    net::TcpStream,
+};
 
 pub struct SshConnection {
     address: IpAddr,
@@ -199,59 +206,46 @@ impl SshConnection {
     }
 
     /// Push a file from the local machine to the remote machine
+    /// The created file will have permissions 0o777
     pub async fn push_file(&self, source: &Path, dest: &Path) {
         let task = format!("pushing file from {source:?} to {}:{dest:?}", self.address);
         tracing::info!("{task}");
 
-        let channel = self.session.channel_open_session().await.unwrap();
-        channel.request_subsystem(true, "sftp").await.unwrap();
-        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
-        let mut file = sftp
-            .open_with_flags(
-                dest.to_str().unwrap(),
-                OpenFlags::WRITE | OpenFlags::TRUNCATE | OpenFlags::CREATE,
-            )
-            .await
-            .unwrap();
-
-        let mut source = File::open(source)
+        let source = File::open(source)
             .await
             .map_err(|e| anyhow!(e).context(format!("Failed to read from {source:?}")))
             .unwrap();
-
-        let mut bytes = vec![0u8; 1024 * 1024];
-        loop {
-            let read_count = source
-                .read(&mut bytes[..])
-                .await
-                .unwrap_or_else(|e| panic!("{task} failed to read from local disk with {e:?}"));
-            if read_count == 0 {
-                break;
-            }
-            tokio::io::AsyncWriteExt::write_all(&mut file, &bytes[0..read_count])
-                .await
-                .unwrap_or_else(|e| panic!("{task} failed to write to remote server with {e:?}"));
-        }
+        self.push_file_impl(&task, source, dest).await;
     }
 
     /// Create a file on the remote machine at `dest` with the provided bytes.
+    /// The created file will have permissions 0o777
     pub async fn push_file_from_bytes(&self, bytes: &[u8], dest: &Path) {
         let task = format!("pushing raw bytes to {}:{dest:?}", self.address);
         tracing::info!("{task}");
 
-        let channel = self.session.channel_open_session().await.unwrap();
-        channel.request_subsystem(true, "sftp").await.unwrap();
-        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
-        let mut file = sftp
-            .open_with_flags(
+        self.push_file_impl(&task, bytes, dest).await;
+    }
+
+    async fn push_file_impl(&self, task: &str, source: impl AsyncRead + Unpin, dest: &Path) {
+        let sftp = self.open_sftp_session().await;
+        let mut remote_file = sftp
+            .open_with_flags_and_attributes(
                 dest.to_str().unwrap(),
                 OpenFlags::WRITE | OpenFlags::TRUNCATE | OpenFlags::CREATE,
+                FileAttributes {
+                    permissions: Some(0o777),
+                    ..FileAttributes::empty()
+                },
             )
             .await
             .unwrap();
-        tokio::io::AsyncWriteExt::write_all(&mut file, bytes)
+
+        // By default tokio uses an 8KB buffer for reading, I've measured that manually swapping to a 1MB buffer increases performance by 5-10x
+        let mut source = BufReader::with_capacity(1024 * 1024, source);
+        tokio::io::copy_buf(&mut source, &mut remote_file)
             .await
-            .unwrap_or_else(|e| panic!("{task} failed to write to remote server with {e:?}"));
+            .unwrap_or_else(|e| panic!("{task} failed with {e:?}"));
     }
 
     /// Pull a file from the remote machine to the local machine
@@ -259,29 +253,23 @@ impl SshConnection {
         let task = format!("pulling file from {}:{source:?} to {dest:?}", self.address);
         tracing::info!("{task}");
 
-        let channel = self.session.channel_open_session().await.unwrap();
-        channel.request_subsystem(true, "sftp").await.unwrap();
-        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
-        let mut file = sftp.open(source.to_str().unwrap()).await.unwrap();
+        let sftp = self.open_sftp_session().await;
+        let remote_file = sftp.open(source.to_str().unwrap()).await.unwrap();
+        let mut remote_file = BufReader::with_capacity(1024 * 1024, remote_file);
 
         let mut dest = File::create(dest)
             .await
             .map_err(|e| anyhow!(e).context(format!("Failed to read from {source:?}")))
             .unwrap();
+        tokio::io::copy_buf(&mut remote_file, &mut dest)
+            .await
+            .unwrap_or_else(|e| panic!("{task} failed with {e:?}"));
+    }
 
-        let mut bytes = vec![0u8; 1024 * 1024];
-        loop {
-            let read_count = file
-                .read(&mut bytes[..])
-                .await
-                .unwrap_or_else(|e| panic!("{task} failed to read from local disk with {e:?}"));
-            if read_count == 0 {
-                break;
-            }
-            tokio::io::AsyncWriteExt::write_all(&mut dest, &bytes[0..read_count])
-                .await
-                .unwrap_or_else(|e| panic!("{task} failed to write to remote server with {e:?}"));
-        }
+    async fn open_sftp_session(&self) -> SftpSession {
+        let channel = self.session.channel_open_session().await.unwrap();
+        channel.request_subsystem(true, "sftp").await.unwrap();
+        SftpSession::new(channel.into_stream()).await.unwrap()
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,7 @@ ignore = [
 allow = [
     "MIT",
     "ISC",
+    "CC0-1.0",
     "Unicode-3.0",
     "Apache-2.0",
     "BSD-3-Clause",


### PR DESCRIPTION
Previously we used dd over ssh to transfer files, this mysteriously broke, so lets use a proper mechanism for this instead.
I've replaced the dd implementation with an sftp based implementation.

Implemented based on example at: https://github.com/AspectUnk/russh-sftp/blob/master/examples/client.rs