### PR TITLE
Use cat instead of dd for transferring files

### DIFF
--- a/aws-throwaway/examples/aws-throwaway-test-large-file.rs
+++ b/aws-throwaway/examples/aws-throwaway-test-large-file.rs
@@ -28,6 +28,18 @@ async fn main() {
         .await;
     println!("Time to push 100MB file {:?}", start.elapsed());
 
+    let remote_size: usize = instance
+        .ssh()
+        .shell("wc -c some_remote_file")
+        .await
+        .stdout
+        .split_ascii_whitespace()
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(remote_size, FILE_LEN);
+
     let start = Instant::now();
     instance
         .ssh()

--- a/aws-throwaway/src/ssh.rs
+++ b/aws-throwaway/src/ssh.rs
@@ -210,7 +210,7 @@ impl SshConnection {
 
     async fn push_file_impl<R: AsyncReadExt + Unpin>(&self, task: &str, source: R, dest: &Path) {
         let mut channel = self.session.channel_open_session().await.unwrap();
-        let command = format!("dd of='{0}'\nchmod 777 {0}", dest.to_str().unwrap());
+        let command = format!("cat > '{0}'\nchmod 777 {0}", dest.to_str().unwrap());
         channel.exec(true, command).await.unwrap();
 
         let mut stdout = vec![];
@@ -260,7 +260,7 @@ impl SshConnection {
         tracing::info!("{task}");
 
         let mut channel = self.session.channel_open_session().await.unwrap();
-        let command = format!("dd if='{0}'\nchmod 777 {0}", source.to_str().unwrap());
+        let command = format!("cat '{}'", source.to_str().unwrap());
         channel.exec(true, command).await.unwrap();
 
         let mut out = File::create(dest).await.unwrap();


### PR DESCRIPTION
Super minor cleanup.
I was trying to fix an issue where uploaded files were truncated, I couldnt resolve the issue but I did end up with these minor improvements that we may as well land.

* cat is simpler to use than dd and is functionally equivalent
* it doesnt make sense to run chmod on the remote file when pulling, we shouldnt modify that file at all.
* added an assertion to the large file test, to reproduce the bug I was trying (and failed) to fix