### PR TITLE
Release 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-throwaway"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/shotover/aws-throwaway"


### PR DESCRIPTION
Release 0.4.1 as a non-breaking change before merging https://github.com/shotover/aws-throwaway/pull/33

I wanted to avoid bumping the deps for now since it results in duplicate aws-sdk deps in shotover.

I'll land #33 after this