### PR TITLE
Add support for STS users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-ec2",
  "aws-sdk-iam",
+ "aws-sdk-sts",
  "base64",
  "clap",
  "futures",

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -9,12 +9,13 @@ description = "An aws-sdk wrapper to spin up temporary resources."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-use_sdk = ["aws-sdk-ec2", "aws-sdk-iam", "aws-config"]
+use_sdk = ["aws-sdk-ec2", "aws-sdk-iam", "aws-sdk-sts", "aws-config"]
 default = ["use_sdk"]
 
 [dependencies]
 aws-sdk-ec2 = { version = "1.1.0", optional = true }
 aws-sdk-iam = { version = "1.1.0", optional = true }
+aws-sdk-sts = { version = "1.1.0", optional = true }
 aws-config = { version = "1.0.0", optional = true }
 russh = "0.40.0"
 russh-keys = "0.40.0"

--- a/aws-throwaway/src/backend/cli/mod.rs
+++ b/aws-throwaway/src/backend/cli/mod.rs
@@ -750,8 +750,24 @@ sudo systemctl start ssh
 }
 
 async fn user_name() -> String {
-    let GetUser::User { user_name } = run_command(&["iam", "get-user"]).await.unwrap();
-    user_name
+    match iam_user_name().await {
+        Ok(name) => name,
+        Err(err) => {
+            tracing::debug!("Failed to run iam get-user, falling back to STS, error was: {err:?}");
+            sts_user_id().await
+        }
+    }
+}
+
+async fn iam_user_name() -> Result<String> {
+    let IamGetUser::User { user_name } = run_command(&["iam", "get-user"]).await?;
+    Ok(user_name)
+}
+
+async fn sts_user_id() -> String {
+    let StsGetCallerIdentity { user_id } =
+        run_command(&["sts", "get-caller-identity"]).await.unwrap();
+    user_id
 }
 
 async fn run_command_empty_response(args: &[&str]) -> Result<()> {
@@ -790,9 +806,15 @@ async fn run_command_string(args: &[&str]) -> Result<String> {
 }
 
 #[derive(serde::Deserialize)]
-enum GetUser {
+enum IamGetUser {
     User {
         #[serde(alias = "UserName")]
         user_name: String,
     },
+}
+
+#[derive(serde::Deserialize)]
+struct StsGetCallerIdentity {
+    #[serde(alias = "UserId")]
+    user_id: String,
 }

--- a/aws-throwaway/src/backend/sdk/iam.rs
+++ b/aws-throwaway/src/backend/sdk/iam.rs
@@ -1,15 +1,38 @@
+use anyhow::Result;
 use aws_config::SdkConfig;
 
 pub async fn user_name(config: &SdkConfig) -> String {
+    match iam_user_name(config).await {
+        Ok(name) => name,
+        Err(err) => {
+            tracing::debug!("Failed to run iam get-user, falling back to STS, error was: {err:?}");
+            sts_user_id(config).await
+        }
+    }
+}
+
+pub async fn iam_user_name(config: &SdkConfig) -> Result<String> {
     let client = aws_sdk_iam::Client::new(config);
-    client
+    Ok(client
         .get_user()
+        .send()
+        .await
+        .map_err(|e| e.into_service_error())?
+        .user()
+        .unwrap()
+        .user_name()
+        .to_string())
+}
+
+pub async fn sts_user_id(config: &SdkConfig) -> String {
+    let client = aws_sdk_sts::Client::new(config);
+    client
+        .get_caller_identity()
         .send()
         .await
         .map_err(|e| e.into_service_error())
         .unwrap()
-        .user()
+        .user_id()
         .unwrap()
-        .user_name()
         .to_string()
 }


### PR DESCRIPTION
Some organizations use tokens provided by STS which fail with the current IAM based approach of fetching the username.
This PR introduces the STS equivalent as a fallback.