### PR TITLE
Various bugfixes

### DIFF
--- a/aws-throwaway/src/backend/sdk/aws.rs
+++ b/aws-throwaway/src/backend/sdk/aws.rs
@@ -160,7 +160,8 @@ impl Aws {
                     .unwrap();
                 tracing::info!("created security group");
 
-                let mut futures = FuturesUnordered::<Pin<Box<dyn Future<Output = ()>>>>::new();
+                let mut futures =
+                    FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::new();
                 futures.push(Box::pin(Aws::create_ingress_rule_internal(
                     client, tags, name,
                 )));


### PR DESCRIPTION
The `+ Send` change is a fix for a bug introduced by https://github.com/shotover/aws-throwaway/pull/43
It actually broke our public interface by changing the type of the future that is created by the async method `create_security_group` as well as its caller and its caller and its caller...
Finally resulting in this very weird error in the users application if they expect the future to be Sync. (which we do)
![image](https://github.com/shotover/aws-throwaway/assets/5120858/06993bc2-8b4f-4874-9240-8782f243d655)


The rest are bugs introduced by https://github.com/shotover/aws-throwaway/pull/41 from poor testing on my part.
They can be reproduced by running the [aws-throwaway-test-multiple-instances.rs](https://github.com/shotover/aws-throwaway/blob/main/aws-throwaway/examples/aws-throwaway-test-multiple-instances.rs) example which I originally neglected to do.