### PR TITLE
add serialize/deserialize functionality to Ec2Instance

### DIFF
--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -26,8 +26,6 @@ anyhow = "1.0.42"
 uuid = { version = "1.0.0", features = ["serde", "v4"] }
 tracing = "0.1.15"
 async-trait = "0.1.30"
-# TODO: avoid pulling in these dependencies when use_sdk is enabled,
-#       will need to introduce a use_cli feature to do so
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
 futures = "0.3.30"

--- a/aws-throwaway/src/ec2_instance_definition.rs
+++ b/aws-throwaway/src/ec2_instance_definition.rs
@@ -1,6 +1,6 @@
 use crate::InstanceType;
 
-/// Defines an instance that can be launched via [`Aws::create_ec2_instance`]
+/// Defines an instance that can be launched via [`crate::Aws::create_ec2_instance`]
 pub struct Ec2InstanceDefinition {
     pub(crate) instance_type: InstanceType,
     pub(crate) volume_size_gb: u32,

--- a/aws-throwaway/src/lib.rs
+++ b/aws-throwaway/src/lib.rs
@@ -122,6 +122,6 @@ pub enum CleanupResources {
     /// Cleanup resources created by all [`Aws`] instances that use [`CleanupResources::WithAppTag`] of the same tag.
     /// It is highly reccomended that this tag is hardcoded, generating this tag could easily lead to forgotten resources.
     WithAppTag(String),
-    /// Cleanup resources created by all [`Aws`] instances regardless of whether it was created via [`CleanupResources::AllResources`] or [`CleanupResources::ResourcesMatchingTag`]
+    /// Cleanup resources created by all [`Aws`] instances regardless of whether it was created via [`CleanupResources::AllResources`] or [`CleanupResources::WithAppTag`]
     AllResources,
 }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,10 @@ aws-throwaway makes it trivial to spin up an instance, interact with it, and the
 ```rust
 let aws = Aws::builder(CleanupResources::AllResources).build().await;
 
-let instance = aws.create_ec2_instance(Ec2InstanceDefinition::new(InstanceType::T2Micro)).await;
+let instance = aws.create_ec2_instance(
+    Ec2InstanceDefinition::new(InstanceType::T2Micro)
+).await;
+
 let output = instance.ssh().shell("echo 'Hello world!'").await;
 println!("output from ec2 instance: {}", output.stdout);
 


### PR DESCRIPTION
This PR goes a bit against the guarantees of aws-throwaway around the cleaning up of resources.
But I've found that windsock needs some way to persist ec2 instances across bench runs: https://github.com/shotover/shotover-proxy/pull/1453