### PR TITLE
Release 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-throwaway"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/shotover/aws-throwaway"


### PR DESCRIPTION
non-breaking release for https://github.com/shotover/aws-throwaway/pull/48