### PR TITLE
CLI backend: fix user-data

### DIFF
--- a/aws-throwaway/src/backend/cli/mod.rs
+++ b/aws-throwaway/src/backend/cli/mod.rs
@@ -6,7 +6,6 @@ use crate::{
     Ec2Instance, Ec2InstanceDefinition, InstanceOs, NetworkInterface, APP_TAG_NAME, USER_TAG_NAME,
 };
 use anyhow::{anyhow, Result};
-use base64::Engine;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 pub use instance_type::InstanceType;
@@ -589,7 +588,6 @@ sudo systemctl start ssh
 "#,
             self.host_public_key, self.host_private_key
         );
-        let user_data = base64::engine::general_purpose::STANDARD.encode(user_data);
         let block_device_mappings = format!(
             "DeviceName=/dev/sda1,Ebs={{DeleteOnTermination=true,VolumeSize={},VolumeType=gp2}}",
             definition.volume_size_gb


### PR DESCRIPTION
The user-data field is kind of cursed and will accept plaintext or base64 encoded plaintext which it automatically detects somehow.

However sometimes this automatic detection does not occur and the user-data remains as undecoded base64  and I cannot find any specification of what the base64 format needs to look like for it to automatically decode it.

So, to avoid this issue I am just directly passing in the user-data without base64 encoding.
And come to think of it, its just simpler all around if we dont have to encode as base64.