### PR TITLE
Disable secondary interfaces by default

### DIFF
--- a/aws-throwaway/src/backend/cli/mod.rs
+++ b/aws-throwaway/src/backend/cli/mod.rs
@@ -13,6 +13,7 @@ pub use instance_type::InstanceType;
 pub use placement_strategy::PlacementStrategy;
 use serde::Deserialize;
 use ssh_key::{rand_core::OsRng, PrivateKey};
+use std::fmt::Write;
 use std::future::Future;
 use std::pin::Pin;
 use std::{
@@ -578,8 +579,19 @@ impl Aws {
             "AvailabilityZone={AZ},GroupName={}",
             self.placement_group_name
         );
+        // Secondary interfaces should not be used until they are configured.
+        let mut bring_down_secondary_interfaces = String::new();
+        for i in 1..definition.network_interface_count {
+            writeln!(
+                bring_down_secondary_interfaces,
+                "sudo ip link set dev ens{} down",
+                5 + i
+            )
+            .unwrap();
+        }
         let user_data = format!(
             r#"#!/bin/bash
+{bring_down_secondary_interfaces}
 sudo systemctl stop ssh
 echo "{}" > /etc/ssh/ssh_host_ed25519_key.pub
 echo "{}" > /etc/ssh/ssh_host_ed25519_key


### PR DESCRIPTION
Having secondary interfaces up results in connection issues sometimes, so we disable all secondary interfaces on startup (ens6 and onwards)
The user can then enable + configure it as needed.