### PR TITLE
Tweaks for running on our system

### DIFF
--- a/aws-throwaway/src/lib.rs
+++ b/aws-throwaway/src/lib.rs
@@ -16,6 +16,7 @@ pub struct AwsBuilder {
     cleanup: CleanupResources,
     use_public_addresses: bool,
     vpc_id: Option<String>,
+    az_name: Option<String>,
     subnet_id: Option<String>,
     placement_strategy: PlacementStrategy,
     security_group_id: Option<String>,
@@ -28,8 +29,8 @@ pub struct AwsBuilder {
 /// * you want to connect directly from within the VPC
 /// * you have already created a specific VPC, subnet or security group that you want aws-throwaway to make use of.
 ///
-/// All resources will be created in us-east-1c.
-/// This is hardcoded so that aws-throawaway only has to look into one region when cleaning up.
+/// All resources will be created in us-east-1.
+/// This is hardcoded so that aws-throwaway only has to look into one region when cleaning up.
 /// All instances are created in a single spread placement group in a single AZ to ensure consistent latency between instances.
 // TODO: document minimum required access for default configuration.
 impl AwsBuilder {
@@ -38,6 +39,7 @@ impl AwsBuilder {
             cleanup,
             use_public_addresses: true,
             vpc_id: None,
+            az_name: None,
             subnet_id: None,
             // refer to: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html
             // I believe Spread is the best default since it is the easiest for amazon to fulfill and gives the most realistic results in benchmarks.
@@ -68,6 +70,15 @@ impl AwsBuilder {
     /// The default is `None`
     pub fn use_vpc_id(mut self, vpc_id: Option<String>) -> Self {
         self.vpc_id = vpc_id;
+        self
+    }
+
+    /// * Some(_) => All resources will go into the specified AZ
+    /// * None => All resources will go into the default AZ (us-east-1c)
+    ///
+    /// The default is `None`
+    pub fn use_az(mut self, az_name: Option<String>) -> Self {
+        self.az_name = az_name;
         self
     }
 


### PR DESCRIPTION
In order to run within a new internal system we need to make two changes to aws-throwaway:
* The AZ needs to be configurable, it is not suitable to run within us-east-1c in our system since it does not have a default subnet.
* EBS must be encrypted in our internal system. This can just be set globally without a config since for the use cases aws-throwaway is targeting whether or not encryption is enabled does not matter.

Additionally the error message is improved in the case where the selected AZ has no default subnet.