### PR TITLE
Release aws_throwaway 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aws-throwaway"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/aws-throwaway/Cargo.toml
+++ b/aws-throwaway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-throwaway"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/shotover/aws-throwaway"


### PR DESCRIPTION
Non-breaking change: dependencies updated since last release are not part of public API.